### PR TITLE
NIDAQMXunit updated

### DIFF
--- a/SESComponents.stat
+++ b/SESComponents.stat
@@ -2,8 +2,8 @@
 EditorSecs=2132
 DesignerSecs=1
 InspectorSecs=1
-CompileSecs=72437
-OtherSecs=694
+CompileSecs=76770
+OtherSecs=697
 StartTime=18/02/2016 16:00:02
 RealKeys=0
 EffectiveKeys=0


### PR DESCRIPTION
NIDAQmxunit updated. NIMX_CheckMaxADCChannels removed from ADCToMemory() to make it execute  faster. ADU .> V calibration factors removed since no longer used.